### PR TITLE
Remove movement grid; use counters instead

### DIFF
--- a/combat-master/src/components/MainActionButton.tsx
+++ b/combat-master/src/components/MainActionButton.tsx
@@ -7,7 +7,7 @@ interface MainActionButtonProps extends NavigationInjectedProps {
   destination: string;
 }
 
-export const MainActionButton: React.FC<MainActionButtonProps> = props => {
+export const MainActionButton: React.FC<MainActionButtonProps> = (props) => {
   const { navigate } = props.navigation;
   return (
     <View style={styles.buttonContainer}>
@@ -24,12 +24,12 @@ const styles = StyleSheet.create({
   buttonContainer: {
     backgroundColor: "#000",
     alignItems: "center",
-    margin: 20
+    margin: 20,
   },
   button: {
     backgroundColor: "#000",
     width: 260,
-    alignItems: "center"
+    alignItems: "center",
   },
   buttonText: {
     textAlign: "center",
@@ -37,6 +37,5 @@ const styles = StyleSheet.create({
     color: "white",
     fontSize: 16,
     fontWeight: "bold",
-    fontFamily: "serif"
-  }
+  },
 });

--- a/combat-master/src/components/MoveCounter.tsx
+++ b/combat-master/src/components/MoveCounter.tsx
@@ -1,0 +1,14 @@
+import React, { useState } from "react";
+import { View, Text, Button } from "react-native";
+
+export const MoveCounter = (props) => {
+  const [selectedMoves, updateSelectedMoves] = useState([])
+
+  return (
+    <View>
+    <Button title="diagonal" onPress = {() => updateSelectedMoves([...selectedMoves, "diagonal"])} />
+    <Button title="orthagonal" onPress = {() => updateSelectedMoves([...selectedMoves, "orthagonal"])}/>
+    {selectedMoves.map((move, index) => <Text key={index}>{move}</Text>)}
+    </View>
+  );
+};

--- a/combat-master/src/components/Toggle.tsx
+++ b/combat-master/src/components/Toggle.tsx
@@ -10,6 +10,7 @@ interface ToggleProps {
 const Label = styled.Text`
   font-size: 20;
   font-weight: bold;
+  background-color: ${(props) => (props.expanded ? "papayawhip" : "white")};
 `;
 
 export const Toggle: React.FC<ToggleProps> = (props: ToggleProps) => {
@@ -19,7 +20,9 @@ export const Toggle: React.FC<ToggleProps> = (props: ToggleProps) => {
 
   return (
     <>
-      <Label onPress={() => toggleExpand(!expanded)}>{label}</Label>
+      <Label onPress={() => toggleExpand(!expanded)} expanded={expanded}>
+        {label}
+      </Label>
       {expanded ? <Text>{bodyText}</Text> : null}
     </>
   );

--- a/combat-master/src/components/Toggle.tsx
+++ b/combat-master/src/components/Toggle.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Text } from "react-native";
 import styled from "styled-components";
 
-interface ToggleProps {
+export interface ToggleProps {
   label: string;
   bodyText: string;
 }

--- a/combat-master/src/components/actions.ts
+++ b/combat-master/src/components/actions.ts
@@ -1,57 +1,54 @@
-interface Action {
-  name: string;
-  fullText: string;
-}
+import { ToggleProps } from "./Toggle";
 
-export const actions: Action[] = [
+export const actions: ToggleProps[] = [
   {
-    name: "Attack",
-    fullText:
+    label: "Attack",
+    bodyText:
       'The most common action to take in combat is the Attack action, whether you are swinging a sword, firing an arrow from a bow, or brawling with your fists. With this action, you make one melee or ranged attack. See the "Making an Attack" section for the rules that govern attacks. Certain features, such as the Extra Attack feature of the fighter, allow you to make more than one attack with this action.',
   },
   {
-    name: "Cast a spell",
-    fullText:
+    label: "Cast a spell",
+    bodyText:
       "Spellcasters such as wizards and clerics, as well as many monsters, have access to spells and can use them to great effect in combat. Each spell has a casting time, which specifies whether the caster must use an action, a reaction, minutes, or even hours to cast the spell. Casting a spell is, therefore, not necessarily an action. Most spells do have a casting time of 1 action, so a spellcaster often uses his or her action in combat to cast such a spell.",
   },
   {
-    name: "Dash",
-    fullText:
+    label: "Dash",
+    bodyText:
       "When you take the Dash action, you gain extra movement for the current turn. The increase equals your speed, after applying any modifiers. With a speed of 30 feet, for example, you can move up to 60 feet on your turn if you dash. Any increase or decrease to your speed changes this additional movement by the same amount. If your speed of 30 feet is reduced to 15 feet, for instance, you can move up to 30 feet this turn if you dash.",
   },
   {
-    name: "Disengage",
-    fullText:
+    label: "Disengage",
+    bodyText:
       "If you take the Disengage action, your movement doesn't provoke opportunity attacks for the rest of the turn.",
   },
   {
-    name: "Dodge",
-    fullText:
+    label: "Dodge",
+    bodyText:
       "When you take the Dodge action, you focus entirely on avoiding attacks. Until the start of your next turn, any attack roll made against you has disadvantage if you can see the attacker, and you make Dexterity saving throws with advantage. You lose this benefit if you are srd:incapacitated or if your speed drops to 0.",
   },
   {
-    name: "Help",
-    fullText:
+    label: "Help",
+    bodyText:
       "You can lend your aid to another creature in the completion of a task. When you take the Help action, the creature you aid gains advantage on the next ability check it makes to perform the task you are helping with, provided that it makes the check before the start of your next turn. Alternatively, you can aid a friendly creature in attacking a creature within 5 feet of you. You feint, distract the target, or in some other way team up to make your ally's attack more effective. If your ally attacks the target before your next turn, the first attack roll is made with advantage.",
   },
   {
-    name: "Hide",
-    fullText:
+    label: "Hide",
+    bodyText:
       "When you take the Hide action, you make a Dexterity (Stealth) check in an attempt to hide, following the rules for hiding. If you succeed, you gain certain benefits, as described in srd:unseen-attackers-and-targets.",
   },
   {
-    name: "Ready",
-    fullText:
+    label: "Ready",
+    bodyText:
       'Sometimes you want to get the jump on a foe or wait for a particular circumstance before you act. To do so, you can take the Ready action on your turn, which lets you act using your reaction before the start of your next turn.First, you decide what perceivable circumstance will trigger your reaction. Then, you choose the action you will take in response to that trigger, or you choose to move up to your speed in response to it. Examples include "If the cultist steps on the trapdoor, I\'ll pull the lever that opens it," and "If the goblin steps next to me, I move away." When the trigger occurs, you can either take your reaction right after the trigger finishes or ignore the trigger. Remember that you can take only one reaction per round. When you ready a spell, you cast it as normal but hold its energy, which you release with your reaction when the trigger occurs. To be readied, a spell must have a casting time of 1 action, and holding onto the spell\'s magic requires concentration. If your concentration is broken, the spell dissipates without taking effect. For example, if you are concentrating on the srd:web spell and ready srd:magic-missile, your srd:web spell ends, and if you take damage before you release srd:magic-missile with your reaction, your concentration might be broken.',
   },
   {
-    name: "Search",
-    fullText:
+    label: "Search",
+    bodyText:
       "When you take the Search action, you devote your attention to finding something. Depending on the nature of your search, the GM might have you make a Wisdom (Perception) check or an Intelligence (Investigation) check.",
   },
   {
-    name: "Use object",
-    fullText:
+    label: "Use object",
+    bodyText:
       "You normally interact with an object while doing something else, such as when you draw a sword as part of an attack. When an object requires your action for its use, you take the Use an Object action. This action is also useful when you want to interact with more than one object on your turn.",
   },
 ];

--- a/combat-master/src/components/movement.ts
+++ b/combat-master/src/components/movement.ts
@@ -1,0 +1,8 @@
+import { ToggleProps } from "./Toggle";
+
+export const movement: ToggleProps[] = [
+  {
+    label: "Dash",
+    bodyText: "tktk",
+  },
+];

--- a/combat-master/src/screens/combatScreens/ActionScreen.tsx
+++ b/combat-master/src/screens/combatScreens/ActionScreen.tsx
@@ -13,7 +13,7 @@ export const ActionScreen: React.FC<ActionScreenProps> = (props) => {
     <>
       <ScrollView>
         {actions.map((action, index) => {
-          return <Toggle label={action.name} bodyText={action.fullText} key={index} />;
+          return <Toggle label={action.label} bodyText={action.bodyText} key={index} />;
         })}
       </ScrollView>
       {/* displayed information scrollview */}

--- a/combat-master/src/screens/combatScreens/MoveScreen.tsx
+++ b/combat-master/src/screens/combatScreens/MoveScreen.tsx
@@ -1,99 +1,20 @@
 import React from "react";
 import { View, Button } from "react-native";
-import SelectableGrid from "react-native-selectable-grid";
 import { NavigationInjectedProps } from "react-navigation";
+import { Toggle } from "../../components/Toggle";
+import { movement } from "../../components/movement";
+import { MoveCounter } from '../../components/MoveCounter'
 
 interface MoveScreenProps extends NavigationInjectedProps {}
-
-const gridData = [
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "0" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-  { label: "" },
-];
 
 export const MoveScreen: React.FC<MoveScreenProps> = (props) => {
   const { navigate } = props.navigation;
   return (
     <View>
-      <SelectableGrid data={gridData} maxPerRow={9} maxSelect={10} />
+      {movement.map((move, index) => {
+        return <Toggle label={move.label} bodyText={move.bodyText} key={index} />;
+      })}
+      <MoveCounter />
       <Button title="Finished" onPress={() => navigate("MainCombatAction")} />
     </View>
   );

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "react-native": "https://github.com/expo/react-native/archive/sdk-35.0.0.tar.gz",
     "react-native-gesture-handler": "~1.3.0",
     "react-native-reanimated": "~1.2.0",
-    "react-native-selectable-grid": "^0.3.1",
     "react-native-web": "^0.11.7",
     "react-navigation": "^4.0.10",
     "react-navigation-stack": "^1.10.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4376,13 +4376,6 @@ react-native-safe-area-view@^0.14.1:
   dependencies:
     debounce "^1.2.0"
 
-react-native-selectable-grid@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/react-native-selectable-grid/-/react-native-selectable-grid-0.3.1.tgz#f0c8a6e1612c93fd82f176be01486e3ebf2628a9"
-  integrity sha512-9HVZwZwQWb4S3HW3fGOusNu1kuVPkzPX4WFNnJ4Oy48t99/o6dzOGjGGwNbtMHeP+OFaOGCP216dkXxKUOC84A==
-  dependencies:
-    prop-types "^15.5.10"
-
 react-native-view-shot@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/react-native-view-shot/-/react-native-view-shot-2.6.0.tgz#3b23675826f67658366352c4b97b59a6aded2f43"


### PR DESCRIPTION
Tried to use selectable grid, but became too complicated when we tried to use custom logic on selectable squares. Also, long and messy. Instead, we decided to simplify it, and use a counter system, with hopes of bringing back some kind of matrix in the future.