### PR TITLE
Style movement screen

### DIFF
--- a/combat-master/src/components/MainActionButton.tsx
+++ b/combat-master/src/components/MainActionButton.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { NavigationInjectedProps } from "react-navigation";
 import styled from "styled-components/native";
+import { CinzelRegular, LatoLight } from "./styledComponents/FontComponents";
 
 interface MainActionButtonProps extends NavigationInjectedProps {
   buttonText: string;
@@ -18,22 +19,12 @@ const LargeButton = styled.TouchableOpacity`
   justify-content: center;
 `;
 
-const ButtonText = styled.Text`
-  font-family: Cinzel_400Regular;
-  font-size: 30px;
-`;
-
-const SecondaryText = styled.Text`
-  font-size: 15px;
-  font-family: Lato_300Light;
-`;
-
 export const MainActionButton: React.FC<MainActionButtonProps> = (props) => {
   const { navigate } = props.navigation;
   return (
     <LargeButton onPress={() => navigate(props.destination)}>
-      <ButtonText>{props.buttonText}</ButtonText>
-      <SecondaryText>{props.secondaryText}</SecondaryText>
+      <CinzelRegular size="30">{props.buttonText}</CinzelRegular>
+      <LatoLight size="15">{props.secondaryText}</LatoLight>
     </LargeButton>
   );
 };

--- a/combat-master/src/components/MoveCounter.tsx
+++ b/combat-master/src/components/MoveCounter.tsx
@@ -11,7 +11,7 @@ interface MoveCounterProps {
 }
 
 const MovementButton = styled.TouchableOpacity`
-  background: rgba(86, 204, 242, 0.25);
+  background: ${(props) => (props.color ? props.color : "#fff")};
   border: 1px solid #000000;
   border-radius: 2px;
   width: 170px;
@@ -25,7 +25,7 @@ const ButtonContainer = styled.View`
   justify-content: space-evenly;
 `;
 
-const MovementContainer = styled.View`
+const MovementLog = styled.View`
   background: rgba(245, 237, 214, 0.5);
   align-items: center;
   margin: 20px;
@@ -61,36 +61,36 @@ export const MoveCounter: React.FC<MoveCounterProps> = (props) => {
   return (
     <View>
       <ButtonContainer>
-        <MovementButton onPress={() => dispatch(updateSelectedMoves("diagonal"))}>
+        <MovementButton color="rgba(86, 204, 242, 0.25)" onPress={() => dispatch(updateSelectedMoves("diagonal"))}>
           <CinzelRegular size="20">Diagonal</CinzelRegular>
         </MovementButton>
-        <MovementButton onPress={() => dispatch(updateSelectedMoves("orthogonal"))}>
+        <MovementButton color="rgba(160, 255, 110, 0.25)" onPress={() => dispatch(updateSelectedMoves("orthogonal"))}>
           <CinzelRegular size="20">Orthogonal</CinzelRegular>
         </MovementButton>
       </ButtonContainer>
-      <MovementContainer>
-        <LatoLight size="30">Total movement (feet):</LatoLight>
+      <MovementLog>
+        <LatoLight size="30">Total movement (ft):</LatoLight>
         <LatoLight size="30">{movementInFeet}</LatoLight>
         {state.selectedMoves.map((move: string, index) => (
           <LatoLight size="20" key={index}>
             {move}
           </LatoLight>
         ))}
-      </MovementContainer>
+      </MovementLog>
       <ButtonContainer>
         <MovementButton
           onPress={() => {
             dispatch(undoLastMove());
           }}
         >
-          <CinzelRegular size="20">Undo last move</CinzelRegular>
+          <CinzelRegular size="20">Undo</CinzelRegular>
         </MovementButton>
         <MovementButton
           onPress={() => {
             dispatch(clearMoves());
           }}
         >
-          <CinzelRegular size="20">Clear moves</CinzelRegular>
+          <CinzelRegular size="20">Clear</CinzelRegular>
         </MovementButton>
       </ButtonContainer>
     </View>

--- a/combat-master/src/components/MoveCounter.tsx
+++ b/combat-master/src/components/MoveCounter.tsx
@@ -2,17 +2,44 @@ import React, { useEffect } from "react";
 import { View, Text, Button } from "react-native";
 import { useSelector, useDispatch } from "react-redux";
 import { updateSelectedMoves, clearMoves, undoLastMove } from "../store/actions";
+import styled from "styled-components/native";
+import { CinzelRegular, LatoLight } from "./styledComponents/FontComponents";
 
 interface MoveCounterProps {
   movementInFeet: number;
   updateMovementInFeet: any;
 }
 
+const MovementButton = styled.TouchableOpacity`
+  background: rgba(86, 204, 242, 0.25);
+  border: 1px solid #000000;
+  border-radius: 2px;
+  width: 170px;
+  height: 50px;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ButtonContainer = styled.View`
+  flex-direction: row;
+  justify-content: space-evenly;
+`;
+
+const MovementContainer = styled.View`
+  background: rgba(245, 237, 214, 0.5);
+  align-items: center;
+  margin: 20px;
+  padding: 20px;
+  height: 75%;
+  overflow: hidden;
+`;
+
 export const MoveCounter: React.FC<MoveCounterProps> = (props) => {
   const state = useSelector((state) => state);
   const dispatch = useDispatch();
 
   const { movementInFeet, updateMovementInFeet } = props;
+
   useEffect(() => {
     let newMovement = 0;
     let alternativeDiagonal = false;
@@ -33,24 +60,39 @@ export const MoveCounter: React.FC<MoveCounterProps> = (props) => {
 
   return (
     <View>
-      <Button title="Diagonal" onPress={() => dispatch(updateSelectedMoves("diagonal"))} />
-      <Button title="Orthogonal" onPress={() => dispatch(updateSelectedMoves("orthogonal"))} />
-      <Button
-        title="Undo last move"
-        onPress={() => {
-          dispatch(undoLastMove());
-        }}
-      />
-      <Button
-        title="Clear moves"
-        onPress={() => {
-          dispatch(clearMoves());
-        }}
-      />
-      {state.selectedMoves.map((move, index) => (
-        <Text key={index}>{move}</Text>
-      ))}
-      <Text>Total movement (feet): {movementInFeet}</Text>
+      <ButtonContainer>
+        <MovementButton onPress={() => dispatch(updateSelectedMoves("diagonal"))}>
+          <CinzelRegular size="20">Diagonal</CinzelRegular>
+        </MovementButton>
+        <MovementButton onPress={() => dispatch(updateSelectedMoves("orthogonal"))}>
+          <CinzelRegular size="20">Orthogonal</CinzelRegular>
+        </MovementButton>
+      </ButtonContainer>
+      <MovementContainer>
+        <LatoLight size="30">Total movement (feet):</LatoLight>
+        <LatoLight size="30">{movementInFeet}</LatoLight>
+        {state.selectedMoves.map((move: string, index) => (
+          <LatoLight size="20" key={index}>
+            {move}
+          </LatoLight>
+        ))}
+      </MovementContainer>
+      <ButtonContainer>
+        <MovementButton
+          onPress={() => {
+            dispatch(undoLastMove());
+          }}
+        >
+          <CinzelRegular size="20">Undo last move</CinzelRegular>
+        </MovementButton>
+        <MovementButton
+          onPress={() => {
+            dispatch(clearMoves());
+          }}
+        >
+          <CinzelRegular size="20">Clear moves</CinzelRegular>
+        </MovementButton>
+      </ButtonContainer>
     </View>
   );
 };

--- a/combat-master/src/components/styledComponents/FontComponents.tsx
+++ b/combat-master/src/components/styledComponents/FontComponents.tsx
@@ -1,0 +1,16 @@
+import styled from "styled-components/native";
+
+export const CinzelRegular = styled.Text`
+  font-family: Cinzel_400Regular;
+  font-size: ${(props) => props.size};
+`;
+
+export const CinzelBold = styled.Text`
+  font-family: Cinzel_700Bold;
+  font-size: ${(props) => props.size};
+`;
+
+export const LatoLight = styled.Text`
+  font-family: Lato_300Light;
+  font-size: ${(props) => props.size};
+`;

--- a/combat-master/src/components/styledComponents/FontComponents.tsx
+++ b/combat-master/src/components/styledComponents/FontComponents.tsx
@@ -3,14 +3,17 @@ import styled from "styled-components/native";
 export const CinzelRegular = styled.Text`
   font-family: Cinzel_400Regular;
   font-size: ${(props) => props.size};
+  color: ${(props) => (props.color ? props.color : "black")};
 `;
 
 export const CinzelBold = styled.Text`
   font-family: Cinzel_700Bold;
   font-size: ${(props) => props.size};
+  color: ${(props) => (props.color ? props.color : "black")};
 `;
 
 export const LatoLight = styled.Text`
   font-family: Lato_300Light;
   font-size: ${(props) => props.size};
+  color: ${(props) => (props.color ? props.color : "black")};
 `;

--- a/combat-master/src/screens/HomeScreen.tsx
+++ b/combat-master/src/screens/HomeScreen.tsx
@@ -3,18 +3,13 @@ import { View, ImageBackground, TouchableOpacity } from "react-native";
 import { NavigationInjectedProps } from "react-navigation";
 import { ProfileScreenProps, DefaultCharacterKey, getCharacterOrPlaceholder } from "./ProfileScreen";
 import styled from "styled-components/native";
+import { CinzelBold } from "../components/styledComponents/FontComponents";
 
 interface HomeScreenProps extends NavigationInjectedProps {}
 
 const ButtonContainer = styled.View`
   margin: 20px;
   align-items: center;
-`;
-
-const ButtonText = styled.Text`
-  font-family: "Cinzel_700Bold";
-  color: #a81414;
-  font-size: 30;
 `;
 
 export const HomeScreen: React.FC<HomeScreenProps> = (props) => {
@@ -30,7 +25,9 @@ export const HomeScreen: React.FC<HomeScreenProps> = (props) => {
       >
         <ButtonContainer>
           <TouchableOpacity onPress={() => navigate("MainCombatAction")}>
-            <ButtonText>Start Combat</ButtonText>
+            <CinzelBold size="30" color="#a81414">
+              Start Combat
+            </CinzelBold>
           </TouchableOpacity>
         </ButtonContainer>
         <ButtonContainer>
@@ -43,7 +40,9 @@ export const HomeScreen: React.FC<HomeScreenProps> = (props) => {
               navigate("Profile", props);
             }}
           >
-            <ButtonText>Character settings</ButtonText>
+            <CinzelBold size="30" color="#a81414">
+              Character Settings
+            </CinzelBold>
           </TouchableOpacity>
         </ButtonContainer>
       </ImageBackground>

--- a/combat-master/src/screens/combatScreens/MoveScreen.tsx
+++ b/combat-master/src/screens/combatScreens/MoveScreen.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { View, Button } from "react-native";
+import { View, Button, TouchableOpacity } from "react-native";
 import { NavigationInjectedProps } from "react-navigation";
 import { MoveCounter } from "../../components/MoveCounter";
 import { updateSelectedMovement } from "../../store/actions";
+import { CinzelBold } from "../../components/styledComponents/FontComponents";
 
 interface MoveScreenProps extends NavigationInjectedProps {}
 
@@ -16,13 +17,15 @@ export const MoveScreen: React.FC<MoveScreenProps> = (props) => {
   return (
     <View>
       <MoveCounter movementInFeet={movementInFeet} updateMovementInFeet={updateMovementInFeet} />
-      <Button
-        title="Finished"
+      <TouchableOpacity
         onPress={() => {
           dispatch(updateSelectedMovement(movementInFeet));
           navigate("MainCombatAction");
         }}
-      />
+        style={{ alignItems: "center" }}
+      >
+        <CinzelBold size="35">Finished</CinzelBold>
+      </TouchableOpacity>
     </View>
   );
 };


### PR DESCRIPTION
Whew more Figma exploration today! Lots of fun learnings around prototyping. After building out a v1 movement screen we were happy with, we went ahead and implemented in the app.

Some things we can do for next time: 
- Make movement log scrollable when there's lots of stuff
- Continue styling action screens
- Dropdown for character settings screen from external API
- Add character to global state