### PR TITLE
Add saved character to Redux state

### DIFF
--- a/combat-master/src/components/MoveCounter.tsx
+++ b/combat-master/src/components/MoveCounter.tsx
@@ -35,7 +35,7 @@ const MovementLog = styled.View`
 `;
 
 export const MoveCounter: React.FC<MoveCounterProps> = (props) => {
-  const state = useSelector((state) => state);
+  const state = useSelector((state) => state.actionReducer);
   const dispatch = useDispatch();
 
   const { movementInFeet, updateMovementInFeet } = props;

--- a/combat-master/src/screens/HomeScreen.tsx
+++ b/combat-master/src/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { View, ImageBackground, TouchableOpacity } from "react-native";
 import { NavigationInjectedProps } from "react-navigation";
 import { ProfileScreenProps, DefaultCharacterKey, getCharacterOrPlaceholder } from "./ProfileScreen";
@@ -17,6 +17,14 @@ const ButtonContainer = styled.View`
 export const HomeScreen: React.FC<HomeScreenProps> = (props) => {
   const { navigate } = props.navigation;
   const dispatch = useDispatch();
+  useEffect(() => {
+    async function getCharacter() {
+      const character = await getCharacterOrPlaceholder(DefaultCharacterKey);
+      dispatch(updateCharacter(character));
+    }
+
+    getCharacter();
+  }, []);
 
   return (
     <View style={{ flex: 1 }}>
@@ -36,13 +44,8 @@ export const HomeScreen: React.FC<HomeScreenProps> = (props) => {
         </ButtonContainer>
         <ButtonContainer>
           <TouchableOpacity
-            onPress={async () => {
-              const character = await getCharacterOrPlaceholder(DefaultCharacterKey);
-              dispatch(updateCharacter(character));
-              const props: ProfileScreenProps = {
-                currentCharacterValues: character,
-              };
-              navigate("Profile", props);
+            onPress={() => {
+              navigate("Profile");
             }}
           >
             <CinzelBold size="30" color="#a81414">

--- a/combat-master/src/screens/HomeScreen.tsx
+++ b/combat-master/src/screens/HomeScreen.tsx
@@ -4,6 +4,8 @@ import { NavigationInjectedProps } from "react-navigation";
 import { ProfileScreenProps, DefaultCharacterKey, getCharacterOrPlaceholder } from "./ProfileScreen";
 import styled from "styled-components/native";
 import { CinzelBold } from "../components/styledComponents/FontComponents";
+import { updateCharacter } from "../store/actions/characterActions";
+import { useDispatch } from "react-redux";
 
 interface HomeScreenProps extends NavigationInjectedProps {}
 
@@ -14,6 +16,8 @@ const ButtonContainer = styled.View`
 
 export const HomeScreen: React.FC<HomeScreenProps> = (props) => {
   const { navigate } = props.navigation;
+  const dispatch = useDispatch();
+
   return (
     <View style={{ flex: 1 }}>
       <ImageBackground
@@ -34,6 +38,7 @@ export const HomeScreen: React.FC<HomeScreenProps> = (props) => {
           <TouchableOpacity
             onPress={async () => {
               const character = await getCharacterOrPlaceholder(DefaultCharacterKey);
+              dispatch(updateCharacter(character));
               const props: ProfileScreenProps = {
                 currentCharacterValues: character,
               };

--- a/combat-master/src/screens/HomeScreen.tsx
+++ b/combat-master/src/screens/HomeScreen.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect } from "react";
 import { View, ImageBackground, TouchableOpacity } from "react-native";
 import { NavigationInjectedProps } from "react-navigation";
-import { ProfileScreenProps, DefaultCharacterKey, getCharacterOrPlaceholder } from "./ProfileScreen";
+import { DefaultCharacterKey, getCharacterOrPlaceholder } from "./ProfileScreen";
 import styled from "styled-components/native";
 import { CinzelBold } from "../components/styledComponents/FontComponents";
 import { updateCharacter } from "../store/actions/characterActions";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 interface HomeScreenProps extends NavigationInjectedProps {}
 
@@ -17,9 +17,11 @@ const ButtonContainer = styled.View`
 export const HomeScreen: React.FC<HomeScreenProps> = (props) => {
   const { navigate } = props.navigation;
   const dispatch = useDispatch();
+  const state = useSelector((state) => state.characterReducer);
+
   useEffect(() => {
     async function getCharacter() {
-      const character = await getCharacterOrPlaceholder(DefaultCharacterKey);
+      const character = await getCharacterOrPlaceholder(DefaultCharacterKey, state);
       dispatch(updateCharacter(character));
     }
 

--- a/combat-master/src/screens/ProfileScreen.tsx
+++ b/combat-master/src/screens/ProfileScreen.tsx
@@ -36,15 +36,10 @@ const getStoredCharacter = async (key: string) => {
   }
   return;
 };
-const placeholderCharacter: CharacterValues = {
-  name: "Xavier Xiloscient",
-  class: "Bard",
-  level: 6,
-};
 
-export const getCharacterOrPlaceholder = async (key: string) => {
+export const getCharacterOrPlaceholder = async (key: string, characterInState: CharacterValues) => {
   const storedCharacter = await getStoredCharacter(key);
-  return storedCharacter || placeholderCharacter;
+  return storedCharacter || characterInState;
 };
 
 export const ProfileScreen: React.FC<InternalProfileScreenProps> = (props) => {
@@ -61,7 +56,6 @@ export const ProfileScreen: React.FC<InternalProfileScreenProps> = (props) => {
 
   return (
     <View>
-      <Text>Current character values: {JSON.stringify(currentCharacter)}</Text>
       <Formik initialValues={currentCharacter} onSubmit={submit} enableReinitialize>
         {({ handleChange, handleBlur, handleSubmit, values }) => (
           <View>

--- a/combat-master/src/screens/ProfileScreen.tsx
+++ b/combat-master/src/screens/ProfileScreen.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { View, Button, TextInput, AsyncStorage, Text } from "react-native";
 import { NavigationInjectedProps } from "react-navigation";
 import { Formik } from "formik";
+import { useSelector } from "react-redux";
 
 export interface ProfileScreenProps {
   currentCharacterValues: CharacterValues;
@@ -9,7 +10,7 @@ export interface ProfileScreenProps {
 
 type InternalProfileScreenProps = NavigationInjectedProps<ProfileScreenProps>;
 
-interface CharacterValues {
+export interface CharacterValues {
   name: string;
   class: string;
   level: number;
@@ -38,7 +39,7 @@ const getStoredCharacter = async (key: string) => {
 const placeholderCharacter: CharacterValues = {
   name: "Xavier Xiloscient",
   class: "Bard",
-  level: 6
+  level: 6,
 };
 
 export const getCharacterOrPlaceholder = async (key: string) => {
@@ -46,8 +47,9 @@ export const getCharacterOrPlaceholder = async (key: string) => {
   return storedCharacter || placeholderCharacter;
 };
 
-export const ProfileScreen: React.FC<InternalProfileScreenProps> = props => {
+export const ProfileScreen: React.FC<InternalProfileScreenProps> = (props) => {
   const { navigate } = props.navigation;
+  const state = useSelector((state) => state.characterReducer);
 
   const submit = (values: CharacterValues) => {
     storeCharacter(values);

--- a/combat-master/src/screens/ProfileScreen.tsx
+++ b/combat-master/src/screens/ProfileScreen.tsx
@@ -2,7 +2,8 @@ import React, { useEffect, useState } from "react";
 import { View, Button, TextInput, AsyncStorage, Text } from "react-native";
 import { NavigationInjectedProps } from "react-navigation";
 import { Formik } from "formik";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
+import { updateCharacter } from "../store/actions/characterActions";
 
 export interface ProfileScreenProps {
   currentCharacterValues: CharacterValues;
@@ -35,7 +36,6 @@ const getStoredCharacter = async (key: string) => {
   }
   return;
 };
-
 const placeholderCharacter: CharacterValues = {
   name: "Xavier Xiloscient",
   class: "Bard",
@@ -50,14 +50,14 @@ export const getCharacterOrPlaceholder = async (key: string) => {
 export const ProfileScreen: React.FC<InternalProfileScreenProps> = (props) => {
   const { navigate } = props.navigation;
   const state = useSelector((state) => state.characterReducer);
+  const currentCharacter = state;
+  const dispatch = useDispatch();
 
   const submit = (values: CharacterValues) => {
     storeCharacter(values);
+    dispatch(updateCharacter(values));
     navigate("Home");
   };
-
-  const currentCharacter = props.navigation.getParam("currentCharacterValues");
-  const [character] = useState(currentCharacter);
 
   return (
     <View>

--- a/combat-master/src/screens/combatScreens/ActionScreen.tsx
+++ b/combat-master/src/screens/combatScreens/ActionScreen.tsx
@@ -11,7 +11,7 @@ interface ActionScreenProps extends NavigationInjectedProps {}
 export const ActionScreen: React.FC<ActionScreenProps> = (props) => {
   const { navigate } = props.navigation;
   const dispatch = useDispatch();
-  const state = useSelector((state) => state);
+  const state = useSelector((state) => state.actionReducer);
   const [locallySelectedAction, changeLocallySelectedAction] = useState(state.selectedAction);
 
   return (

--- a/combat-master/src/screens/combatScreens/BonusActionScreen.tsx
+++ b/combat-master/src/screens/combatScreens/BonusActionScreen.tsx
@@ -12,7 +12,7 @@ const StyledTextInput = styled(TextInput)`
 `;
 export const BonusActionScreen: React.FC<BonusActionScreenProps> = (props) => {
   const { navigate } = props.navigation;
-  const state = useSelector((state) => state);
+  const state = useSelector((state) => state.actionReducer);
 
   const [localBonusAction, updateLocalBonusAction] = React.useState(state.selectedBonusAction);
   const dispatch = useDispatch();

--- a/combat-master/src/screens/combatScreens/MainCombatActionScreen.tsx
+++ b/combat-master/src/screens/combatScreens/MainCombatActionScreen.tsx
@@ -7,7 +7,7 @@ import { useSelector } from "react-redux";
 interface MainCombatActionScreenProps extends NavigationInjectedProps {}
 
 export const MainCombatActionScreen: React.FC<MainCombatActionScreenProps> = (props) => {
-  const state = useSelector((state) => state);
+  const state = useSelector((state) => state.actionReducer);
   const { navigation } = props;
 
   return (

--- a/combat-master/src/screens/combatScreens/MainCombatActionScreen.tsx
+++ b/combat-master/src/screens/combatScreens/MainCombatActionScreen.tsx
@@ -9,7 +9,6 @@ interface MainCombatActionScreenProps extends NavigationInjectedProps {}
 export const MainCombatActionScreen: React.FC<MainCombatActionScreenProps> = (props) => {
   const state = useSelector((state) => state.actionReducer);
   const { navigation } = props;
-  console.log(useSelector((state) => state.characterReducer));
   return (
     <View style={{ flex: 1 }}>
       <MainActionButton

--- a/combat-master/src/screens/combatScreens/MainCombatActionScreen.tsx
+++ b/combat-master/src/screens/combatScreens/MainCombatActionScreen.tsx
@@ -9,7 +9,7 @@ interface MainCombatActionScreenProps extends NavigationInjectedProps {}
 export const MainCombatActionScreen: React.FC<MainCombatActionScreenProps> = (props) => {
   const state = useSelector((state) => state.actionReducer);
   const { navigation } = props;
-
+  console.log(useSelector((state) => state.characterReducer));
   return (
     <View style={{ flex: 1 }}>
       <MainActionButton

--- a/combat-master/src/screens/combatScreens/MoveScreen.tsx
+++ b/combat-master/src/screens/combatScreens/MoveScreen.tsx
@@ -11,7 +11,7 @@ interface MoveScreenProps extends NavigationInjectedProps {}
 export const MoveScreen: React.FC<MoveScreenProps> = (props) => {
   const { navigate } = props.navigation;
   const dispatch = useDispatch();
-  const state = useSelector((state) => state);
+  const state = useSelector((state) => state.actionReducer);
   const [movementInFeet, updateMovementInFeet] = useState(state.selectedMovement);
 
   return (

--- a/combat-master/src/store/actions/actionTypes.ts
+++ b/combat-master/src/store/actions/actionTypes.ts
@@ -4,3 +4,6 @@ export const UPDATE_BONUS_ACTION = "UPDATE_BONUS_ACTION";
 export const UPDATE_SELECTED_MOVES = "UPDATE_SELECTED_MOVES";
 export const UNDO_LAST_MOVE = "UNDO_LAST_MOVE";
 export const CLEAR_MOVES = "CLEAR_MOVES";
+
+/** Character Action Types */
+export const UPDATE_CHARACTER = "UPDATE_CHARACTER";

--- a/combat-master/src/store/actions/characterActions.ts
+++ b/combat-master/src/store/actions/characterActions.ts
@@ -1,0 +1,9 @@
+import { UPDATE_CHARACTER } from "./actionTypes";
+import { CharacterValues } from "../../screens/ProfileScreen";
+
+export const updateCharacter = (Character: CharacterValues) => {
+  return {
+    type: UPDATE_CHARACTER,
+    payload: Character,
+  };
+};

--- a/combat-master/src/store/configureStore.ts
+++ b/combat-master/src/store/configureStore.ts
@@ -1,4 +1,10 @@
 import { configureStore } from "@reduxjs/toolkit";
-import reducer from "./reducers/root";
+import actionReducer from "./reducers/root";
+import characterReducer from "./reducers/characterReducer";
 
-export const store = configureStore({ reducer: reducer });
+const reducer = {
+  actionReducer: actionReducer,
+  characterReducer: characterReducer,
+};
+
+export const store = configureStore({ reducer });

--- a/combat-master/src/store/reducers/characterReducer.ts
+++ b/combat-master/src/store/reducers/characterReducer.ts
@@ -1,0 +1,24 @@
+import { UPDATE_CHARACTER } from "../actions/actionTypes";
+import { CharacterValues } from "../../screens/ProfileScreen";
+
+const initialState: CharacterValues = {
+  name: "Xavier Xiloscient",
+  class: "Bard",
+  level: 6,
+};
+
+const characterReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case UPDATE_CHARACTER:
+      return {
+        ...state,
+        name: action.payload.name,
+        class: action.payload.class,
+        level: action.payload.level,
+      };
+    default:
+      return state;
+  }
+};
+
+export default characterReducer;

--- a/combat-master/src/store/reducers/root.ts
+++ b/combat-master/src/store/reducers/root.ts
@@ -14,7 +14,7 @@ const initialState = {
   selectedBonusAction: "",
 };
 
-const reducer = (state = initialState, action) => {
+const actionReducer = (state = initialState, action) => {
   switch (action.type) {
     case UPDATE_MOVEMENT:
       return {
@@ -51,4 +51,4 @@ const reducer = (state = initialState, action) => {
   }
 };
 
-export default reducer;
+export default actionReducer;


### PR DESCRIPTION
We spent most of today's session adding a user's saved character to Redux state (and refactoring to split state into multiple slices). Now when opening the Home screen, the user's character is grabbed from device memory and added to Redux state, so we can use it elsewhere in the app without having to fetch from storage every time.

Copy/pasting our backlog:
- Make movement log scrollable when there's lots of stuff
- Continue styling action screens
- Style character settings screen
- Dropdown for character settings screen from external API