### PR TITLE
Visual cleanup

### DIFF
--- a/combat-master/src/components/ActionSelector.tsx
+++ b/combat-master/src/components/ActionSelector.tsx
@@ -14,11 +14,11 @@ const ButtonWrapper = styled.TouchableOpacity`
   border: 1px solid #000;
   background-color: white;
   border-radius: 2px;
+  margin-bottom: 10px;
 `;
 
 const Label = styled(CinzelRegular)<{ selected: boolean }>`
   background-color: ${(props) => (props.selected ? `${lightBlue}` : "white")};
-  width: 100%;
   text-align: center;
 `;
 

--- a/combat-master/src/components/styledComponents/ParchmentBackground.tsx
+++ b/combat-master/src/components/styledComponents/ParchmentBackground.tsx
@@ -4,6 +4,4 @@ import { parchment } from "../../styles/colors";
 export const ParchmentBackground = styled.View`
   background-color: ${parchment};
   padding-bottom: 40px;
-  align-items: center;
-  justify-content: space-between;
 `;

--- a/combat-master/src/screens/InputBonusActionsScreen.tsx
+++ b/combat-master/src/screens/InputBonusActionsScreen.tsx
@@ -47,32 +47,33 @@ export const InputBonusActionsScreen: React.FC = (props) => {
       <View style={{ width: "100%", height: "100%" }}>
         <View style={{ margin: 10, height: "100%" }}>
           <BonusActionList>
-            {characterToStore.bonusActions.map((action, index) => {
-              return (
-                <View key={index} style={{ marginBottom: 15 }}>
-                  <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
-                    <CinzelBold size="24">{action.title}</CinzelBold>
-                    <CinzelBold
-                      size="24"
-                      color={darkRed}
-                      onPress={() => {
-                        const tempBonusActions = [...characterToStore.bonusActions];
-                        tempBonusActions.splice(index, 1);
-                        setCharacterToStore({
-                          ...characterToStore,
-                          bonusActions: [...tempBonusActions],
-                        });
-                      }}
-                    >
-                      X
-                    </CinzelBold>
+            {characterToStore.bonusActions &&
+              characterToStore.bonusActions.map((action, index) => {
+                return (
+                  <View key={index} style={{ marginBottom: 15 }}>
+                    <View style={{ flexDirection: "row", justifyContent: "space-between" }}>
+                      <CinzelBold size="24">{action.title}</CinzelBold>
+                      <CinzelBold
+                        size="24"
+                        color={darkRed}
+                        onPress={() => {
+                          const tempBonusActions = [...characterToStore.bonusActions];
+                          tempBonusActions.splice(index, 1);
+                          setCharacterToStore({
+                            ...characterToStore,
+                            bonusActions: [...tempBonusActions],
+                          });
+                        }}
+                      >
+                        X
+                      </CinzelBold>
+                    </View>
+                    <LatoLight size="14" numberOfLines={2}>
+                      {action.description}
+                    </LatoLight>
                   </View>
-                  <LatoLight size="14" numberOfLines={2}>
-                    {action.description}
-                  </LatoLight>
-                </View>
-              );
-            })}
+                );
+              })}
           </BonusActionList>
 
           <LatoLight size="14" style={{ marginBottom: 10, alignSelf: "flex-start" }}>

--- a/combat-master/src/screens/ProfileScreen.tsx
+++ b/combat-master/src/screens/ProfileScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { View, AsyncStorage, StyleSheet } from "react-native";
+import { AsyncStorage, StyleSheet, ScrollView } from "react-native";
 import { Formik } from "formik";
 import { useSelector, useDispatch } from "react-redux";
 import { updateCharacter } from "../store/actions/characterActions";
@@ -125,10 +125,10 @@ export const ProfileScreen: React.FC<InternalProfileScreenProps> = (props) => {
   };
 
   return (
-    <View>
+    <ScrollView>
       <Formik initialValues={currentCharacter} onSubmit={submit} enableReinitialize>
         {({ handleChange, handleBlur, handleSubmit, values }) => (
-          <ParchmentBackground>
+          <ParchmentBackground style={{ alignItems: "center" }}>
             <FormContainer>
               <Label size={"20"}>Character Name:</Label>
               <StyledInput
@@ -168,6 +168,14 @@ export const ProfileScreen: React.FC<InternalProfileScreenProps> = (props) => {
                   return { label: className, value: className };
                 })}
               />
+              <AddBonusActionButton
+                onPress={() => {
+                  navigate("InputBonusActionsScreen");
+                }}
+                style={{ alignSelf: "center", marginBottom: 20, width: "100%" }}
+              >
+                <CinzelRegular size="20">Input bonus actions</CinzelRegular>
+              </AddBonusActionButton>
             </FormContainer>
             <FinishedButton
               text="Save & return"
@@ -178,15 +186,7 @@ export const ProfileScreen: React.FC<InternalProfileScreenProps> = (props) => {
           </ParchmentBackground>
         )}
       </Formik>
-      <AddBonusActionButton
-        onPress={() => {
-          navigate("InputBonusActionsScreen");
-        }}
-        style={{ alignSelf: "center", marginBottom: 20, width: "100%" }}
-      >
-        <CinzelRegular size="20">Input bonus actions</CinzelRegular>
-      </AddBonusActionButton>
-    </View>
+    </ScrollView>
   );
 };
 

--- a/combat-master/src/screens/combatScreens/ActionScreen.tsx
+++ b/combat-master/src/screens/combatScreens/ActionScreen.tsx
@@ -8,6 +8,7 @@ import styled from "styled-components/native";
 import { FinishedButton } from "../../components/FinishedButton";
 import { LatoLight } from "../../components/styledComponents/FontComponents";
 import { ParchmentBackground } from "../../components/styledComponents/ParchmentBackground";
+import { parchment } from "../../styles/colors";
 
 interface ActionScreenProps {}
 
@@ -20,21 +21,22 @@ export const ActionScreen: React.FC<ActionScreenProps> = (props) => {
   const ActionDescription = styled.ScrollView`
     border: solid 1px #000;
     padding: 5px;
-    flex: 3;
     margin-top: 10;
     background-color: white;
+    height: 200px;
   `;
 
-  const ActionContainer = styled.View`
+  const ActionContainer = styled.ScrollView`
     margin-left: 10px;
     margin-right: 10px;
     margin-top: 10px;
+    flex: 1;
   `;
 
   return (
-    <ParchmentBackground>
+    <ParchmentBackground style={{ flex: 1 }}>
       <ActionContainer>
-        <View style={{ flex: 5, justifyContent: "space-between" }}>
+        <View style={{ flex: 3, justifyContent: "space-between" }}>
           {actions.map((action, index) => {
             const isCurrentlySelectedAction = action.label === locallySelectedAction;
             return (
@@ -53,7 +55,7 @@ export const ActionScreen: React.FC<ActionScreenProps> = (props) => {
             {actions.filter((action) => action.label === locallySelectedAction)[0].bodyText}
           </LatoLight>
         </ActionDescription>
-        <View style={{ flex: 0.5, marginTop: 10 }}>
+        <View style={{ marginTop: 10, flex: 1 }}>
           <FinishedButton
             onPress={() => {
               dispatch(updateSelectedAction(locallySelectedAction));

--- a/combat-master/src/screens/combatScreens/BonusActionScreen.tsx
+++ b/combat-master/src/screens/combatScreens/BonusActionScreen.tsx
@@ -30,9 +30,10 @@ export const BonusActionScreen: React.FC<BonusActionScreenProps> = (props) => {
       >
         {actions.selectedBonusAction}
       </StyledTextInput>
-      {character.bonusActions.map((action, index) => {
-        return <Text key={index}>{action.title}</Text>;
-      })}
+      {character.bonusActions &&
+        character.bonusActions.map((action, index) => {
+          return <Text key={index}>{action.title}</Text>;
+        })}
       <Button
         title="Confirm bonus action"
         onPress={() => {


### PR DESCRIPTION
Things we did:
- Moved around the link from Profile to Input Bonus Actions
- Stopped the Actions screen contents from resizing weirdly + getting cut off on smaller devices
- Added some checks before trying to map through bonusActions on the character so that we don't crash the app as much when they're empty

Things we learned:
- To connect react native debugger, open a new tab w/ port 19001 in the application AND activate the debugger in expo by hitting `cmd + d`
- When a parent of a ScrollView has `alignItems: center`, you may get strange behavior when combined with `flex` (see https://github.com/facebook/react-native/issues/3825)
- If you want to use flex on components, their parent has to also have `flex` (maybe `flex: 1` specifically?)
- Formik is fine with you having stuff inside the form that isn't doing anything with form values
- We have a weird edge case where if a user gets into a state where `bonusActions` in the Redux store is `undefined`, we cannot add new actions to the bonus actions list. This theoretically shouldn't happen, since we have a default value of `[]` set
