### PR TITLE
add optional chaining to character access

### DIFF
--- a/combat-master/src/screens/combatScreens/BonusActionScreen.tsx
+++ b/combat-master/src/screens/combatScreens/BonusActionScreen.tsx
@@ -47,14 +47,14 @@ export const BonusActionScreen: React.FC<BonusActionScreenProps> = (props) => {
                 />
               );
             })}
-          {character.bonusActions.length !== 0 && (
+          {character?.bonusActions?.length !== 0 && (
             <ActionSelector
               label={noSelectedActionLabel}
               isCurrentlySelectedAction={noSelectedActionLabel === localBonusAction}
               updateParentState={updateLocalBonusAction}
             />
           )}
-          {character.bonusActions.length !== 0 && (
+          {character?.bonusActions?.length !== 0 && (
             <>
               <LatoLight size="14" style={{ marginVertical: 10, alignSelf: "flex-start" }}>
                 Selected action description
@@ -62,7 +62,7 @@ export const BonusActionScreen: React.FC<BonusActionScreenProps> = (props) => {
               <ActionDescription>
                 <LatoLight size="14px">
                   {
-                    character.bonusActions.filter((bonusAction) => bonusAction.title === localBonusAction)[0]
+                    character?.bonusActions?.filter((bonusAction) => bonusAction.title === localBonusAction)[0]
                       ?.description
                   }
                 </LatoLight>


### PR DESCRIPTION
Before: if you had no custom bonus actions input, the bonus action screen would crash because we were trying to access properties like `length` on something that didn't exist yet

After: no crashes!